### PR TITLE
Optional type casting

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,37 @@ All schema definitions are supported, $schema is ignored.
 ### Types
 All types are supported
 
-### String Formats
+### Formats
+#### Disabling the format keyword.
+
+You may disable format validation by providing `disableFormat: true` to the validator
+options.
+
+#### String Formats
 All formats are supported, phone numbers are expected to follow the [E.123](http://en.wikipedia.org/wiki/E.123) standard.
+
+#### Custom Formats
+You may add your own custom format functions.  Format functions accept the input
+being validated and return a boolean value.  If the returned value is `true`, then
+validation succeeds.  If the returned value is `false`, then validation fails.
+
+* Formats added to `Validator.prototype.customFormats` do not affect previously instantiated
+Validators.  This is to prevent validator instances from being altered once created.
+It is conceivable that multiple validators may be created to handle multiple schemas
+with different formats in a program.
+* Formats added to `validator.customFormats` affect only that Validator instance.
+
+Here is an example that uses custom formats:
+
+```
+Validator.prototype.customFormats.myFormat = function(input) {
+  return input === 'myFormat';
+};
+
+var validator = new Validator();
+validator.validate('myFormat', {type: 'string', format: 'myFormat'}).valid; // true
+validator.validate('foo', {type: 'string', format: 'myFormat'}).valid; // false
+```
 
 ### Results
 The first error found will be thrown as an `Error` object if `options.throwError` is `true`.  Otherwise all results will be appended to the `result.errors` array which also contains the success flag `result.valid`.

--- a/examples/all.js
+++ b/examples/all.js
@@ -292,34 +292,34 @@ var schema = {
     //
     // The property must match one or more of the validation schema provided in
     // the array, which can be as simple or complex and nested as desired.
-    "validateAnyOf": [
+    "validateAnyOf": { "anyOf" : [
       {
         "type": "boolean"
       },
       {
         "type": "string"
       }
-    ],
+    ]},
     // The property must match all of the validation schema provided in the
     // array, which can be as simple or complex and nested as desired.
-    "validateAllOf": [
+    "validateAllOf": { "allOf" : [
       {
         "type": "boolean"
       },
       {
         "enum": [true]
       }
-    ],
+    ]},
     // The property must match only one of the validation schema provided in the
     // array, which can be as simple or complex and nested as desired.
-    "validateOneOf": [
+    "validateOneOf": { "oneOf" : [
       {
         "type": "boolean"
       },
       {
         "type": "integer"
       }
-    ],
+    ]},
 
     // --------------------------------------------------------------------
     // References.

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -498,8 +498,9 @@ validators.pattern = function validatePattern (instance, schema, options, ctx) {
 };
 
 /**
- * Validates whether the instance value is of a certain defined format, when the instance value is a string.
- * The following format are supported:
+ * Validates whether the instance value is of a certain defined format or a custom
+ * format.
+ * The following formats are supported for string types:
  *   - date-time
  *   - date
  *   - time
@@ -518,11 +519,8 @@ validators.pattern = function validatePattern (instance, schema, options, ctx) {
  * @return {String|null}
  */
 validators.format = function validateFormat (instance, schema, options, ctx) {
-  if (!(typeof instance === 'string')) {
-    return null;
-  }
   var result = new ValidatorResult(instance, schema, options, ctx);
-  if (!helpers.isFormat(instance, schema.format)) {
+  if (!result.disableFormat && !helpers.isFormat(instance, schema.format, this)) {
     result.addError({
       name: 'format',
       argument: schema.format,

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -44,7 +44,7 @@ validators.type = function validateType (instance, schema, options, ctx) {
     return null;
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
-  var types = (schema.type instanceof Array) ? schema.type : [schema.type];
+  var types = Array.isArray(schema.type) ? schema.type : [schema.type];
   if (!types.some(this.testType.bind(this, instance, schema, options, ctx))) {
     var list = types.map(function (v) {
       return v.id && ('<' + v.id + '>') || (v+'');
@@ -76,7 +76,7 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
     return null;
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
-  if (!(schema.anyOf instanceof Array)){
+  if (!Array.isArray(schema.anyOf)){
     throw new SchemaError("anyOf must be an array");
   }
   if (!schema.anyOf.some(testSchema.bind(this, instance, options, ctx))) {
@@ -105,7 +105,7 @@ validators.allOf = function validateAllOf (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
-  if (!(schema.allOf instanceof Array)){
+  if (!Array.isArray(schema.allOf)){
     throw new SchemaError("allOf must be an array");
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
@@ -138,7 +138,7 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
-  if (!(schema.oneOf instanceof Array)){
+  if (!Array.isArray(schema.oneOf)){
     throw new SchemaError("oneOf must be an array");
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
@@ -311,7 +311,7 @@ validators.maxProperties = function validateMaxProperties (instance, schema, opt
  * @return {String|null|ValidatorResult}
  */
 validators.items = function validateItems (instance, schema, options, ctx) {
-  if (!(instance instanceof Array)) {
+  if (!Array.isArray(instance)) {
     return null;
   }
   var self = this;
@@ -320,7 +320,7 @@ validators.items = function validateItems (instance, schema, options, ctx) {
     return result;
   }
   instance.every(function (value, i) {
-    var items = (schema.items instanceof Array) ? (schema.items[i] || schema.additionalItems) : schema.items;
+    var items = Array.isArray(schema.items) ? (schema.items[i] || schema.additionalItems) : schema.items;
     if (items === undefined) {
       return true;
     }
@@ -579,7 +579,7 @@ validators.maxLength = function validateMaxLength (instance, schema, options, ct
  * @return {String|null}
  */
 validators.minItems = function validateMinItems (instance, schema, options, ctx) {
-  if (!(instance instanceof Array)) {
+  if (!Array.isArray(instance)) {
     return null;
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
@@ -600,7 +600,7 @@ validators.minItems = function validateMinItems (instance, schema, options, ctx)
  * @return {String|null}
  */
 validators.maxItems = function validateMaxItems (instance, schema, options, ctx) {
-  if (!(instance instanceof Array)) {
+  if (!Array.isArray(instance)) {
     return null;
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
@@ -624,7 +624,7 @@ validators.maxItems = function validateMaxItems (instance, schema, options, ctx)
  */
 validators.uniqueItems = function validateUniqueItems (instance, schema, options, ctx) {
   var result = new ValidatorResult(instance, schema, options, ctx);
-  if (!(instance instanceof Array)) {
+  if (!Array.isArray(instance)) {
     return result;
   }
   function testArrays (v, i, a) {
@@ -666,7 +666,7 @@ function testArrays (v, i, a) {
  * @return {String|null}
  */
 validators.uniqueItems = function validateUniqueItems (instance, schema, options, ctx) {
-  if (!(instance instanceof Array)) {
+  if (!Array.isArray(instance)) {
     return null;
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
@@ -701,7 +701,7 @@ validators.dependencies = function validateDependencies (instance, schema, optio
     if (typeof dep == 'string') {
       dep = [dep];
     }
-    if (dep instanceof Array) {
+    if (Array.isArray(dep)) {
       dep.forEach(function (prop) {
         if (instance[prop] === undefined) {
           result.addError({
@@ -737,7 +737,7 @@ validators.dependencies = function validateDependencies (instance, schema, optio
  * @return {ValidatorResult|null}
  */
 validators['enum'] = function validateEnum (instance, schema, options, ctx) {
-  if (!(schema['enum'] instanceof Array)) {
+  if (!Array.isArray(schema['enum'])) {
     throw new SchemaError("enum expects an array", schema);
   }
   if (instance === undefined) {
@@ -768,7 +768,7 @@ validators.not = validators.disallow = function validateNot (instance, schema, o
   var result = new ValidatorResult(instance, schema, options, ctx);
   var notTypes = schema.not || schema.disallow;
   if(!notTypes) return null;
-  if(!(notTypes instanceof Array)) notTypes=[notTypes];
+  if(!Array.isArray(notTypes)) notTypes=[notTypes];
   notTypes.forEach(function (type) {
     if (self.testType(instance, schema, options, ctx, type)) {
       var schemaId = type && type.id && ('<' + type.id + '>') || type;

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -45,7 +45,7 @@ validators.type = function validateType (instance, schema, options, ctx) {
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
   var types = Array.isArray(schema.type) ? schema.type : [schema.type];
-  if (!types.some(this.testType.bind(this, instance, schema, options, ctx))) {
+  if (!types.some(this.testType.bind(this, instance, schema, result, options, ctx))) {
     var list = types.map(function (v) {
       return v.id && ('<' + v.id + '>') || (v+'');
     });
@@ -770,7 +770,7 @@ validators.not = validators.disallow = function validateNot (instance, schema, o
   if(!notTypes) return null;
   if(!Array.isArray(notTypes)) notTypes=[notTypes];
   notTypes.forEach(function (type) {
-    if (self.testType(instance, schema, options, ctx, type)) {
+    if (self.testType(instance, schema, result, options, ctx, type)) {
       var schemaId = type && type.id && ('<' + type.id + '>') || type;
       result.addError({
         name: 'not',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -59,15 +59,15 @@ ValidatorResult.prototype.importErrors = function importErrors(res) {
   if (typeof res == 'string' || (res && res.validatorType)) {
     this.addError(res);
   } else if (res && res.errors) {
-    var errs = this.errors;
-    res.errors.forEach(function (v) {
-      errs.push(v);
-    });
+    Array.prototype.push.apply(this.errors, res.errors);
   }
 };
 
+function stringizer (v,i){
+  return i+': '+v.toString()+'\n';
+}
 ValidatorResult.prototype.toString = function toString(res) {
-  return this.errors.map(function(v,i){ return i+': '+v.toString()+'\n'; }).join('');
+  return this.errors.map(stringizer).join('');
 };
 
 Object.defineProperty(ValidatorResult.prototype, "valid", { get: function() {
@@ -210,44 +210,52 @@ exports.deepCompareStrict = function deepCompareStrict (a, b) {
   return a === b;
 };
 
-module.exports.deepMerge = function deepMerge (target, src) {
+function deepMerger (target, dst, e, i) {
+  if (typeof e === 'object') {
+    dst[i] = deepMerge(target[i], e)
+  } else {
+    if (target.indexOf(e) === -1) {
+      dst.push(e)
+    }
+  }
+}
+
+function copyist (src, dst, key) {
+  dst[key] = src[key];
+}
+
+function copyistWithDeepMerge (target, src, dst, key) {
+  if (typeof src[key] !== 'object' || !src[key]) {
+    dst[key] = src[key];
+  }
+  else {
+    if (!target[key]) {
+      dst[key] = src[key];
+    } else {
+      dst[key] = deepMerge(target[key], src[key])
+    }
+  }
+}
+
+function deepMerge (target, src) {
   var array = Array.isArray(src);
   var dst = array && [] || {};
 
   if (array) {
     target = target || [];
     dst = dst.concat(target);
-    src.forEach(function (e, i) {
-      if (typeof e === 'object') {
-        dst[i] = deepMerge(target[i], e)
-      } else {
-        if (target.indexOf(e) === -1) {
-          dst.push(e)
-        }
-      }
-    });
+    src.forEach(deepMerger.bind(null, target, dst));
   } else {
     if (target && typeof target === 'object') {
-      Object.keys(target).forEach(function (key) {
-        dst[key] = target[key];
-      });
+      Object.keys(target).forEach(copyist.bind(null, target, dst));
     }
-    Object.keys(src).forEach(function (key) {
-      if (typeof src[key] !== 'object' || !src[key]) {
-        dst[key] = src[key];
-      }
-      else {
-        if (!target[key]) {
-          dst[key] = src[key];
-        } else {
-          dst[key] = deepMerge(target[key], src[key])
-        }
-      }
-    });
+    Object.keys(src).forEach(copyistWithDeepMerge.bind(null, target, src, dst));
   }
 
   return dst;
 };
+
+module.exports.deepMerge = deepMerge;
 
 /**
  * Validates instance against the provided schema
@@ -267,6 +275,9 @@ exports.objectGetPath = function objectGetPath(o, s) {
   return o;
 };
 
+function pathEncoder (v) {
+  return '/'+encodeURIComponent(v).replace(/~/g,'%7E');
+}
 /**
  * Accept an Array of property names and return a JSON Pointer URI fragment
  * @param Array a
@@ -275,5 +286,5 @@ exports.objectGetPath = function objectGetPath(o, s) {
 exports.encodePath = function encodePointer(a){
 	// ~ must be encoded explicitly because hacks
 	// the slash is encoded by encodeURIComponent
-	return a.map(function(v){ return '/'+encodeURIComponent(v).replace(/~/g,'%7E'); }).join('');
+	return a.map(pathEncoder).join('');
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -34,6 +34,7 @@ var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instanc
   this.propertyPath = ctx.propertyPath;
   this.errors = [];
   this.throwError = options && options.throwError;
+  this.disableFormat = options && options.disableFormat === true;
 };
 
 ValidatorResult.prototype.addError = function addError(detail) {
@@ -149,14 +150,17 @@ FORMAT_REGEXPS.regexp = FORMAT_REGEXPS.regex;
 FORMAT_REGEXPS.pattern = FORMAT_REGEXPS.regex;
 FORMAT_REGEXPS.ipv4 = FORMAT_REGEXPS['ip-address'];
 
-exports.isFormat = function isFormat (input, format) {
-  if (FORMAT_REGEXPS[format] !== undefined) {
+exports.isFormat = function isFormat (input, format, validator) {
+  if (typeof input === 'string' && FORMAT_REGEXPS[format] !== undefined) {
     if (FORMAT_REGEXPS[format] instanceof RegExp) {
       return FORMAT_REGEXPS[format].test(input);
     }
     if (typeof FORMAT_REGEXPS[format] === 'function') {
       return FORMAT_REGEXPS[format](input);
     }
+  } else if (validator && validator.customFormats &&
+      typeof validator.customFormats[format] === 'function') {
+    return validator.customFormats[format](input);
   }
   return true;
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -11,7 +11,7 @@ export declare class Validator {
     attributes: {[property:string]: CustomProperty};
 
     addSchema(schema?: Schema, uri?: string): Schema|void;
-    validate(instance: any, schema: Schema, options?: Options, ctx?: SchemaContext);
+    validate(instance: any, schema: Schema, options?: Options, ctx?: SchemaContext): ValidatorResult;
 }
 
 export declare class ValidatorResult {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,7 +8,7 @@ export declare class Validator {
     schemas: {[id:string]: Schema};
     unresolvedRefs: string[];
 
-    attributes: {(property:string): CustomProperty};
+    attributes: {[property:string]: CustomProperty};
 
     addSchema(schema?: Schema, uri?: string): Schema|void;
     validate(instance: any, schema: Schema, options?: Options, ctx?: SchemaContext);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,123 @@
+/*
+This is type definition for typescript.
+This is for library users. Thus, properties and methods for internal use is omitted.
+ */
+export declare class Validator {
+    constructor();
+    customFormats: CustomFormat[];
+    schemas: {[id:string]: Schema};
+    unresolvedRefs: string[];
+
+    attributes: {(property:string): CustomProperty};
+
+    addSchema(schema?: Schema, uri?: string): Schema|void;
+    validate(instance: any, schema: Schema, options?: Options, ctx?: SchemaContext);
+}
+
+export declare class ValidatorResult {
+    constructor(instance: any, schema: Schema, options: Options, ctx: SchemaContext)
+    instance: any;
+    schema: Schema;
+    propertyPath: string;
+    errors: ValidationError[];
+    throwError: boolean;
+    disableFormat: boolean;
+    valid: boolean;
+    addError(detail:string|ErrorDetail): ValidationError;
+    toString(): string;
+}
+
+export declare class ValidationError {
+    constructor(message?: string, instance?: any, schema?: Schema, propertyPath?: any, name?: string, argument?: any);
+    property: string;
+    message: string;
+    schema: string|Schema;
+    instance: any;
+    name: string;
+    argument: any;
+    toString(): string;
+}
+
+export declare class SchemaError extends Error{
+    constructor(msg: string, schema: Schema);
+    schema: Schema;
+    message: string;
+}
+
+export declare function validate(instance: any, schema: any, options?: Options): ValidatorResult
+
+export interface Schema {
+    id?: string
+    $schema?: string
+    title?: string
+    description?: string
+    multipleOf?: number
+    maximum?: number
+    exclusiveMaximum?: boolean
+    minimum?: number
+    exclusiveMinimum?: boolean
+    maxLength?: number
+    minLength?: number
+    pattern?: string
+    additionalItems?: boolean | Schema
+    items?: Schema | Schema[]
+    maxItems?: number
+    minItems?: number
+    uniqueItems?: boolean
+    maxProperties?: number
+    minProperties?: number
+    required?: string[]
+    additionalProperties?: boolean | Schema
+    definitions?: {
+        [name: string]: Schema
+    }
+    properties?: {
+        [name: string]: Schema
+    }
+    patternProperties?: {
+        [name: string]: Schema
+    }
+    dependencies?: {
+        [name: string]: Schema | string[]
+    }
+    'enum'?: any[]
+    type?: string | string[]
+    allOf?: Schema[]
+    anyOf?: Schema[]
+    oneOf?: Schema[]
+    not?: Schema
+}
+
+export interface Options {
+    skipAttributes?: string[];
+    allowUnknownAttributes?: boolean;
+    rewrite?: RewriteFunction;
+    propertyName?: string;
+    base?: string;
+}
+
+export interface RewriteFunction {
+    (instance: any, schema: Schema, options: Options, ctx: SchemaContext): any;
+}
+
+export interface SchemaContext {
+    schema: Schema;
+    options: Options;
+    propertyPath: string;
+    base: string;
+    schemas: {[base:string]: Schema};
+}
+
+export interface CustomFormat {
+    (input: any): boolean;
+}
+
+export interface CustomProperty {
+    (instance: any, schema: Schema, options: Options, ctx: SchemaContext): string|ValidatorResult;
+}
+
+export interface ErrorDetail {
+    message: string;
+    name: string;
+    argument: string;
+}

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -157,6 +157,16 @@ Validator.prototype.validate = function validate (instance, schema, options, ctx
 };
 
 /**
+* @param Object schema
+* @return mixed schema uri or false
+*/
+function shouldResolve(schema) {
+  var ref = (typeof schema === 'string') ? schema : schema.$ref;
+  if (typeof ref=='string') return ref;
+  return false;
+}
+
+/**
  * Validates an instance against the schema (the actual work horse)
  * @param instance
  * @param schema
@@ -166,41 +176,21 @@ Validator.prototype.validate = function validate (instance, schema, options, ctx
  * @return {ValidatorResult}
  */
 Validator.prototype.validateSchema = function validateSchema (instance, schema, options, ctx) {
-  var self = this;
   var result = new ValidatorResult(instance, schema, options, ctx);
   if (!schema) {
     throw new Error("schema is undefined");
   }
 
-  /**
-  * @param Object schema
-  * @return mixed schema uri or false
-  */
-  function shouldResolve(schema) {
-    var ref = (typeof schema === 'string') ? schema : schema.$ref;
-    if (typeof ref=='string') return ref;
-    return false;
-  }
-  /**
-  * @param Object schema
-  * @param SchemaContext ctx
-  * @returns Object schema or resolved schema
-  */
-  function resolve(schema, ctx) {
-    var ref;
-    if(ref = shouldResolve(schema)) {
-      return self.resolve(schema, ref, ctx).subschema;
-    }
-    return schema;
-  }
-
   if (schema['extends']) {
     if (schema['extends'] instanceof Array) {
-      schema['extends'].forEach(function (s) {
-        schema = helpers.deepMerge(schema, resolve(s, ctx));
-      });
+      var schemaobj = {schema: schema, ctx: ctx};
+      schema['extends'].forEach(this.schemaTraverser.bind(this, schemaobj));
+      schema = schemaobj.schema;
+      schemaobj.schema = null;
+      schemaobj.ctx = null;
+      schemaobj = null;
     } else {
-      schema = helpers.deepMerge(schema, resolve(schema['extends'], ctx));
+      schema = helpers.deepMerge(schema, this.superResolve(schema['extends'], ctx));
     }
   }
 
@@ -216,9 +206,9 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
   for (var key in schema) {
     if (!attribute.ignoreProperties[key] && skipAttributes.indexOf(key) < 0) {
       var validatorErr = null;
-      var validator = self.attributes[key];
+      var validator = this.attributes[key];
       if (validator) {
-        validatorErr = validator.call(self, instance, schema, options, ctx);
+        validatorErr = validator.call(this, instance, schema, options, ctx);
       } else if (options.allowUnknownAttributes === false) {
         // This represents an error with the schema itself, not an invalid instance
         throw new SchemaError("Unsupported attribute: " + key, schema);
@@ -235,6 +225,30 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
   }
   return result;
 };
+
+/**
+* @private
+* @param Object schema
+* @param SchemaContext ctx
+* @returns Object schema or resolved schema
+*/
+Validator.prototype.schemaTraverser = function schemaTraverser (schemaobj, s) {
+  schemaobj.schema = helpers.deepMerge(schemaobj.schema, this.superResolve(s, schemaobj.ctx));
+}
+
+/**
+* @private
+* @param Object schema
+* @param SchemaContext ctx
+* @returns Object schema or resolved schema
+*/
+Validator.prototype.superResolve = function superResolve (schema, ctx) {
+  var ref;
+  if(ref = shouldResolve(schema)) {
+    return this.resolve(schema, ref, ctx).subschema;
+  }
+  return schema;
+}
 
 /**
 * @private

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -14,6 +14,9 @@ var SchemaContext = helpers.SchemaContext;
  * @constructor
  */
 var Validator = function Validator () {
+  // Allow a validator instance to override global custom formats or to have their
+  // own custom formats.
+  this.customFormats = Object.create(Validator.prototype.customFormats);
   this.schemas = {};
   this.unresolvedRefs = [];
 
@@ -21,6 +24,9 @@ var Validator = function Validator () {
   this.types = Object.create(types);
   this.attributes = Object.create(attribute.validators);
 };
+
+// Allow formats to be registered globally.
+Validator.prototype.customFormats = {};
 
 // Hint at the presence of a property
 Validator.prototype.schemas = null;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -205,7 +205,7 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
   if(options.setDefaults && typeof instance === 'undefined' && schema.required !== true) {
       result.instance = instance = schema.default;
   }
-  
+
   var skipAttributes = options && options.skipAttributes || [];
   // Validate each schema attribute against the instance
   for (var key in schema) {
@@ -214,6 +214,9 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
       var validator = this.attributes[key];
       if (validator) {
         validatorErr = validator.call(this, instance, schema, options, ctx);
+        if (validatorErr && result.instance) {
+          result.instance = validatorErr.instance
+        }
       } else if (options.allowUnknownAttributes === false) {
         // This represents an error with the schema itself, not an invalid instance
         throw new SchemaError("Unsupported attribute: " + key, schema);
@@ -293,9 +296,9 @@ Validator.prototype.resolve = function resolve (schema, switchSchema, ctx) {
  * @param type
  * @return {boolean}
  */
-Validator.prototype.testType = function validateType (instance, schema, options, ctx, type) {
+Validator.prototype.testType = function validateType (instance, schema, result, options, ctx, type) {
   if (typeof this.types[type] == 'function') {
-    return this.types[type].call(this, instance);
+    return this.types[type].call(this, instance, result, options);
   }
   if (type && typeof type == 'object') {
     var res = this.validateSchema(instance, type, options, ctx);
@@ -306,32 +309,51 @@ Validator.prototype.testType = function validateType (instance, schema, options,
 };
 
 var types = Validator.prototype.types = {};
-types.string = function testString (instance) {
+types.string = function testString (instance, result, options) {
+  // If the provided type is a number, cast it to string
+  if (typeof instance == 'number' && options.castTypes) {
+    result.instance = instance.toString();
+    return true;
+  }
   return typeof instance == 'string';
 };
-types.number = function testNumber (instance) {
+types.number = function testNumber (instance, result, options) {
   // isFinite returns false for NaN, Infinity, and -Infinity
+  // If the provided type is a string, cast it to a number
+  if (typeof instance == 'string' && options.castTypes) {
+    let num = parseFloat(instance)
+    if (isNaN(num)) return false;
+    result.instance = num;
+    return true;
+  }
   return typeof instance == 'number' && isFinite(instance);
 };
-types.integer = function testInteger (instance) {
+types.integer = function testInteger (instance, result, options) {
+  // If the provided type is a string, cast it to a number
+  if (typeof instance == 'string' && options.castTypes) {
+    let num = parseFloat(instance)
+    if (isNaN(num) || instance % 1 !== 0) return false;
+    result.instance = num;
+    return true;
+  }
   return (typeof instance == 'number') && instance % 1 === 0;
 };
-types.boolean = function testBoolean (instance) {
+types.boolean = function testBoolean (instance, result, options) {
   return typeof instance == 'boolean';
 };
-types.array = function testArray (instance) {
+types.array = function testArray (instance, result, options) {
   return instance instanceof Array;
 };
-types['null'] = function testNull (instance) {
+types['null'] = function testNull (instance, result, options) {
   return instance === null;
 };
-types.date = function testDate (instance) {
+types.date = function testDate (instance, result, options) {
   return instance instanceof Date;
 };
-types.any = function testAny (instance) {
+types.any = function testAny (instance, result, options) {
   return true;
 };
-types.object = function testObject (instance) {
+types.object = function testObject (instance, result, options) {
   // TODO: fix this - see #15
   return instance && (typeof instance) === 'object' && !(instance instanceof Array) && !(instance instanceof Date);
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Tom de Grunt <tom@degrunt.nl>",
   "name": "jsonschema",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": "MIT",
   "dependencies": {
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     { "name" : "Austin Wright" }
   ],
   "main": "./lib",
+  "typings": "./lib/index.d.ts",
   "devDependencies": {
     "mocha": "~1.8.2",
     "chai": "~1.5.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Tom de Grunt <tom@degrunt.nl>",
   "name": "jsonschema",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "dependencies": {
   },

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -12,6 +12,25 @@ describe('Attributes', function () {
       this.validator = new Validator();
     });
 
+    describe('string', function () {
+      it('should validate a valid string', function () {
+        this.validator.validate("foo", {'type': 'string'}).valid.should.be.true;
+      });
+
+      it('should not validate an invalid string', function () {
+        return this.validator.validate(0.25, { 'type': 'string' }).valid.should.be.false;
+      });
+
+      it('should validate an invalid string with casting enabled', function () {
+        return this.validator.validate(0.25, {'type': 'string'}, {castTypes: true}).valid.should.be.true;
+      });
+
+      it('should convert type of invalid string with casting enabled', function () {
+        return typeof (this.validator.validate(2, {'type': 'string'}, {castTypes: true}).instance) == 'number';
+      });
+
+    });
+
     describe('number', function () {
       it('should validate a valid number', function () {
         this.validator.validate(0, {'type': 'number'}).valid.should.be.true;
@@ -19,6 +38,14 @@ describe('Attributes', function () {
 
       it('should not validate an invalid number', function () {
         return this.validator.validate('0', {'type': 'number'}).valid.should.be.false;
+      });
+
+      it('should validate an invalid number with casting enabled', function () {
+        return this.validator.validate('0', {'type': 'number'}, {castTypes: true}).valid.should.be.true;
+      });
+
+       it('should convert type of invalid number with casting enabled', function () {
+        return typeof (this.validator.validate('0', {'type': 'integer'}, {castTypes: true}).instance) == 'number';
       });
 
       it('should not validate NaN', function () {
@@ -78,8 +105,20 @@ describe('Attributes', function () {
         return this.validator.validate(12, {'type': 'integer'}).valid.should.be.true;
       });
 
+      it('should validate invalid integer with casting enabled', function () {
+        return this.validator.validate("12", {'type': 'integer'}, {castTypes: true}).valid.should.be.true;
+      });
+
+      it('should convert type of invalid integer with casting enabled', function () {
+        return typeof (this.validator.validate("12", {'type': 'integer'}, {castTypes: true}).instance) == 'number';
+      });
+
       it('should not validate non integer', function () {
         return this.validator.validate(0.25, {'type': 'integer'}).valid.should.be.false;
+      });
+
+      it('should not validate non integer with casting enabled', function () {
+        return this.validator.validate("0.25", {'type': 'integer'}, {castTypes: true}).valid.should.be.false;
       });
 
       it('should not validate an undefined instance', function () {
@@ -295,27 +334,27 @@ describe('Attributes', function () {
       return this.validator.validate({'the_field':'bar'}, {'type': 'object', 'properties':{'the_field': {'enum': ['foo', 'bar', 'baz'], 'required': true}}}).valid.should.be.true;
     });
   });
-  
+
   describe('default', function () {
     beforeEach(function () {
       this.validator = new Validator();
     });
-    
+
     it('should preserve value if field is defined', function () {
       var validation = this.validator.validate({'the_field': 'foo'}, {'type': 'object', 'properties':{'the_field':{'type': 'string', 'default': 'bar'}}}, {setDefaults: true});
-      validation.valid.should.be.true; 
+      validation.valid.should.be.true;
       validation.instance.the_field.should.equal('foo');
     });
-    
+
     it('should not set default value even field is undefined if options.setDefaults is not true', function () {
       var validation = this.validator.validate({}, {'type': 'object', 'properties':{'the_field':{'type': 'string', 'default': 'bar'}}});
-      validation.valid.should.be.true; 
+      validation.valid.should.be.true;
       validation.instance.should.not.have.property('the_field');
     });
-    
+
     it('should set default value if field is undefined and options.setDefaults is true', function () {
       var validation = this.validator.validate({}, {'type': 'object', 'properties':{'the_field':{'type': 'string', 'default': 'bar'}}}, {setDefaults: true})
-      validation.valid.should.be.true; 
+      validation.valid.should.be.true;
       validation.instance.the_field.should.equal('bar');
     });
   });

--- a/test/formats.js
+++ b/test/formats.js
@@ -272,7 +272,7 @@ describe('Formats', function () {
       };
 
       this.validator.customFormats.float = function(input) {
-        console.log(input);
+        //console.log(input);
         return /^\d+(?:\.\d+)?$/.test(input);
       };
     });

--- a/test/formats.js
+++ b/test/formats.js
@@ -262,6 +262,75 @@ describe('Formats', function () {
     });
   });
 
+  describe('custom formats', function() {
+    beforeEach(function() {
+      this.validator.customFormats.foo = function(input) {
+        if (input === 'foo') {
+          return true;
+        }
+        return false;
+      };
+
+      this.validator.customFormats.float = function(input) {
+        console.log(input);
+        return /^\d+(?:\.\d+)?$/.test(input);
+      };
+    });
+
+    it('should validate input', function() {
+      this.validator.validate("foo", {'type': 'string', 'format': 'foo'}).valid.should.be.true;
+    });
+
+    it('should validate numeric input', function() {
+      this.validator.validate(32.45, {'type': 'number', 'format': 'float'}).valid.should.be.true;
+    });
+
+    it('should fail input that fails validation', function() {
+      this.validator.validate("boo", {'type': 'string', 'format': 'foo'}).valid.should.be.false;
+    });
+
+    it('should fail numeric input that fails validation', function() {
+      this.validator.validate(NaN, {'type': 'number', 'format': 'float'}).valid.should.be.false;
+    });
+
+    describe('assigned to validator instances', function() {
+      var format;
+
+      beforeEach(function() {
+        format = function() {};
+        this.validator.customFormats.boo = format;
+      });
+
+      it('should not be assigned to the Validator prototype', function() {
+        (typeof Validator.prototype.customFormats.boo).should.equal('undefined');
+      });
+    });
+
+    describe('assigned to the Validator.prototype before validator instances are created', function() {
+      var format;
+
+      beforeEach(function() {
+        format = function() {};
+        Validator.prototype.customFormats.boo = format;
+      });
+
+      afterEach(function() {
+        delete Validator.prototype.customFormats.boo;
+      });
+
+      it('should be assigned to the instances', function() {
+        ((new Validator()).customFormats.boo).should.be.a.function;
+      });
+    });
+  });
+
+  describe('with options.disableFormat === true', function() {
+    it('should validate invalid formats', function() {
+      this.validator.validate("2012-07-08", {'type': 'string', 'format': 'date-time'},
+          {disableFormat: true}).valid.should.be.true;
+    });
+  });
+
   describe('invalid format', function() {
     it('should validate', function () {
       this.validator.validate("url", {'type': 'string', 'format': 'url'}).valid.should.be.true;


### PR DESCRIPTION
Added feature of optional type casting.
                                                                                                                                                                                                                                                                                                                                                                   
    - The standard behavior is not changed                                                                                                                                                                  
    - Use option: {castType: true} to enable the feature                                                                                                                                                    
    - If possible wrongly provided types will be casted into the desired type                                                                                                                               
    - The converted types will be made part of the validation result set                                                                                                                                    
    - Added several tests testing and demonstrating the new feature